### PR TITLE
__constructor shouldn't do work

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ use SecureEnvPHP\SecureEnvPHP;
 ```
 Instantiate class with decryption options.
 ```php
-new SecureEnvPHP([
+(new SecureEnvPHP())->parse([
     'path' => '.env.enc',
     'secret' => '.env.key'
 ]);
@@ -64,7 +64,7 @@ require_once './vendor/autoload.php';
 
 use SecureEnvPHP\SecureEnvPHP;
 
-new SecureEnvPHP([
+(new SecureEnvPHP())->parse([
     'path' => '.env.enc',
     'secret' => '.env.key'
 ]);

--- a/src/SecureEnvPHP.php
+++ b/src/SecureEnvPHP.php
@@ -6,7 +6,7 @@ use \SecureEnvPHP\Parser as Parser;
 
 class SecureEnvPHP {
 
-    public function __construct(array $options) {
+    public function parse(array $options): void {
         $crypto = new \SecureEnvPHP\Crypto;
 
         if ($decrypted = $crypto->decrypt($options)) {
@@ -19,5 +19,4 @@ class SecureEnvPHP {
             }
         }
     }
-
 }

--- a/tests/SecureEnvPHPTest.php
+++ b/tests/SecureEnvPHPTest.php
@@ -11,7 +11,8 @@ class SecureEnvPHPTest extends TestCase {
      * Testing with path to env and path to secret key, then retrieving env value
      */
     public function testInitWithSecretPathAndGetEnv() : void {
-        $secureEnv = new SecureEnvPHP([
+        $secureEnv = new SecureEnvPHP();
+        $secureEnv->parse([
             'path' => './tests/.env.enc',
             'secret' => './tests/.env.key'
         ]);
@@ -28,7 +29,8 @@ class SecureEnvPHPTest extends TestCase {
         $secret = fread($key_file, filesize($path));
         fclose($key_file);
         
-        $secureEnv = new SecureEnvPHP([
+        $secureEnv = new SecureEnvPHP();
+        $secureEnv->parse([
             'path' => './tests/.env.enc',
             'secret' => $secret
         ]);


### PR DESCRIPTION
Constructor function must be only used for variable declaration, all other code should be moved into a separate method and called directly.